### PR TITLE
Updated a rule in 4.3.5

### DIFF
--- a/docs/training_manual/vector_classification/classification.rst
+++ b/docs/training_manual/vector_classification/classification.rst
@@ -249,7 +249,7 @@ That's where rule-based classification comes in handy.
 
 * Click the :guilabel:`Add rule` button: |signPlus|.
 * A new dialog then appears.
-* Click the ellipsis :guilabel:`...` button next to the :guilabel:`Filter` text area.
+* Click the epsilon :guilabel:`Ɛ` button next to the :guilabel:`Filter` text area.
 * Using the query builder that appears, enter the criterion
   :kbd:`"landuse" = 'residential' AND "name" <> 'Swellendam'` (or
   :kbd:`"landuse" = 'residential' AND "name" != 'Swellendam'`),
@@ -262,7 +262,7 @@ That's where rule-based classification comes in handy.
 .. image:: img/rule_style_result.png
    :align: center
 
-* Add a new criterion :kbd:`"landuse" <> 'residential' AND "AREA" >= 0.00005`
+* Add a new criterion :kbd:`"landuse" <> 'residential' AND "AREA" >= 1000000`
   and choose a mid-green color.
 * Add another new criterion :kbd:`"name"  =  'Swellendam'` and assign it
   a darker grey-blue color in order to indicate the town's importance in the
@@ -270,7 +270,7 @@ That's where rule-based classification comes in handy.
 * Click and drag this criterion to the top of the list.
 
 These filters are exclusive, in that they collectively exclude some areas on the
-map (i.e. those which are smaller that 0.00005, are not residential and are not
+map (i.e. those which are smaller that 1000000, are not residential and are not
 '|majorUrbanName|'). This means that the excluded polygons take the style of the
 default :guilabel:`(no filter)` category.
 


### PR DESCRIPTION
Lines 265 and 273.

Updated one criterion from "AREA" >= 0.00005` to "AREA" >= 1000000` and one corresponding reference in text.

Classifying 'landuse' layer by `AREA` more or less than 1000000 makes more sense than by 0.00005 as this filters all except `Swellendam` and `Railton` out.

Note: I have also been noticing that my exercise data differs from the example screenshots, but have not found that this massively impacts the learning process when following the training manual.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
